### PR TITLE
docs: add kaizen-update-docs to Kaizen cycle documentation

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -159,6 +159,30 @@ Claude Code がセッションを分析し、以下のような提案を出し�
 
 次にPythonプロジェクトを初期化したとき、Claude Code は knowledge/ からこの知見を読み取り、依存管理ツールを推測せずに確認するようになります。
 
+### 3-5: Update Docs — プロジェクトドキュメントとレジストリの同期
+
+knowledge/ への反映が済んだら、プロジェクト側のドキュメントも最新化します。
+
+```
+/kaizen-update-docs
+```
+
+Claude Code が CLAUDE.md と docs/ を分析し、更新提案を出します:
+
+```markdown
+## ドキュメント更新提案
+
+### docs/ への追加/更新
+
+#### PROJECT_SUMMARY.md
+- 技術スタック: uv を依存管理ツールとして追記
+- status: planning → developing に変更
+
+承認しますか？
+```
+
+承認すると、PROJECT_SUMMARY.md が更新されます。さらに、更新内容がプロジェクトレジストリ（`knowledge/projects/INDEX.md`）にも自動で同期されます。これにより、別のプロジェクトから `/kaizen-suggest-next` を実行したときに、このプロジェクトの最新状況が参照できるようになります。
+
 ---
 
 ## これが Kaizen サイクルです
@@ -167,6 +191,7 @@ Claude Code がセッションを分析し、以下のような提案を出し�
 2. **Plan & Decide**: 何をやるか決める
 3. **Execute**: 実務をこなす（= 普段の作業）
 4. **Reflect**: 引っかかりを知識に変える
+5. **Update Docs**: プロジェクトドキュメントとレジストリを同期する
 
 サイクルを回すたびに knowledge/ が育ち、同じ説明の繰り返し・手戻り・既知の落とし穴が減っていきます。
 
@@ -175,8 +200,7 @@ Claude Code がセッションを分析し、以下のような提案を出し�
 ## Tips
 
 - **knowledge/ のgit管理**: `$KAIZEN_KNOWLEDGE_DIR` で `git init` を実行すると、蓄積された知識の変更履歴を管理できます
-- **セッションの終わりに**: `/kaizen-reflect-learning` を習慣にすると、知識が着実に蓄積されます
-- **ドキュメントの更新**: 作業後に `/kaizen-update-docs` でプロジェクトドキュメントを最新化できます
+- **セッションの終わりに**: `/kaizen-reflect-learning` → `/kaizen-update-docs` を習慣にすると、知識とドキュメントが着実に蓄積されます
 
 ---
 

--- a/framework/knowledge/meta/GETTING_STARTED.md
+++ b/framework/knowledge/meta/GETTING_STARTED.md
@@ -78,14 +78,13 @@ project-root/
 Kaizen-CLIのコマンドは、以下の改善サイクルを構成しています:
 
 ```
-suggest-next → 計画・実行 → reflect-learning → suggest-next → ...
+suggest-next → 計画・実行 → reflect-learning → update-docs → suggest-next → ...
 ```
 
 1. **Suggest**: `/kaizen-suggest-next` — タスク完了後、次のステップを提案
 2. **Plan & Execute**: 提案を元に計画・実行（通常のClaude Code作業）
 3. **Reflect**: `/kaizen-reflect-learning` — セッション終了時、学びをknowledgeに蓄積
-
-ドキュメントに変更があった場合は、reflectの前後で `/kaizen-update-docs` を実行します。
+4. **Update Docs**: `/kaizen-update-docs` — プロジェクトドキュメントを更新し、レジストリに同期
 
 蓄積された知識が次のsuggestの質を高め、サイクルを回すほど改善が加速します。
 
@@ -105,7 +104,7 @@ suggest-next → 計画・実行 → reflect-learning → suggest-next → ...
 |---------|------|--------------|
 | `/kaizen-suggest-next` | 次のステップを提案 | タスク完了時 |
 | `/kaizen-reflect-learning` | 学びをknowledgeファイルに記録 | セッション終了時 |
-| `/kaizen-update-docs` | プロジェクトドキュメントを更新 | docs/やCLAUDE.mdの変更後 |
+| `/kaizen-update-docs` | プロジェクトドキュメントを更新し、レジストリに同期 | reflect後、またはドキュメント更新が必要なとき |
 
 ---
 


### PR DESCRIPTION
QUICKSTART.md にウォークスルーステップ 3-5 として update-docs を追加し、
レジストリ同期の流れを具体例で説明。GETTING_STARTED.md のサイクル図と
コマンド表も update-docs を正式なステップとして反映。

https://claude.ai/code/session_01Lq6dL7zHRRtcm7NgFrgVLy