### PR TITLE
fix: reflect のタイミングを「セッション終了時」から「作業が一段落ついたとき」に修正

### DIFF
--- a/docs/CONCEPT.ja.md
+++ b/docs/CONCEPT.ja.md
@@ -121,7 +121,7 @@ Claude Code の plan mode を活用し、提案されたアクションの実行
 
 ### Reflect — 引っかかりが知識に変わる
 
-セッション終了時に `/kaizen-reflect-learning` を実行します。作業中に生じた引っかかりを分析し、knowledge/ に反映します。
+作業が一段落ついたときに `/kaizen-reflect-learning` を実行します。作業中に生じた引っかかりを分析し、knowledge/ に反映します。
 
 - 失敗パターンと成功アプローチの対比
 - 暗黙のルールの明文化

--- a/docs/CONCEPT.md
+++ b/docs/CONCEPT.md
@@ -122,7 +122,7 @@ Leverages Claude Code's plan mode to build an execution plan for suggested actio
 
 ### Reflect — Turning Friction into Knowledge
 
-Run `/kaizen-reflect-learning` at the end of a session. It analyzes friction encountered during your work and reflects it into knowledge/.
+Run `/kaizen-reflect-learning` when your work reaches a natural stopping point. It analyzes friction encountered during your work and reflects it into knowledge/.
 
 - Contrasts failure patterns with successful approaches
 - Makes implicit rules explicit

--- a/docs/QUICKSTART.ja.md
+++ b/docs/QUICKSTART.ja.md
@@ -175,7 +175,7 @@ Claude Code がセッションを分析し、以下のような提案を出し�
 ## Tips
 
 - **knowledge/ のgit管理**: `$KAIZEN_KNOWLEDGE_DIR` で `git init` を実行すると、蓄積された知識の変更履歴を管理できます
-- **セッションの終わりに**: `/kaizen-reflect-learning` を習慣にすると、知識が着実に蓄積されます
+- **作業が一段落ついたら**: `/kaizen-reflect-learning` を習慣にすると、知識が着実に蓄積されます
 - **ドキュメントの更新**: 作業後に `/kaizen-update-docs` でプロジェクトドキュメントを最新化できます
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -200,7 +200,7 @@ With each cycle, knowledge/ grows, and repeated explanations, rework, and known 
 ## Tips
 
 - **Version-control knowledge/**: Run `git init` in `$KAIZEN_KNOWLEDGE_DIR` to track changes to your accumulated knowledge
-- **At the end of each session**: Make `/kaizen-reflect-learning` → `/kaizen-update-docs` a habit to steadily build up knowledge and keep documentation in sync
+- **When work reaches a stopping point**: Make `/kaizen-reflect-learning` → `/kaizen-update-docs` a habit to steadily build up knowledge and keep documentation in sync
 
 ---
 

--- a/framework/CLAUDE.md.template
+++ b/framework/CLAUDE.md.template
@@ -14,7 +14,7 @@
 1. `docs/PROJECT_SUMMARY.md` の各セクションを埋める
 2. `knowledge/` の関連ファイルを確認する
 3. 実装を開始する — Claudeが必要なファイルを生成する
-4. セッション終了時に `/kaizen-reflect-learning` で学びを記録する
+4. 作業が一段落ついたら `/kaizen-reflect-learning` で学びを記録する
 
 ## 参考ドキュメント
 


### PR DESCRIPTION
reflectはセッションの終了に縛られるものではなく、作業の区切りで
実行するのがkaizen-cliの本来のコンセプト。5箇所の記述を統一的に修正。

https://claude.ai/code/session_01WyBQ4tMnPwp6gqnf4thP12