### PR TITLE
docs: clarify $KAIZEN_CLI_DIR in DESIGN_PRINCIPLES diagram and description

### DIFF
--- a/docs/DESIGN_PRINCIPLES.ja.md
+++ b/docs/DESIGN_PRINCIPLES.ja.md
@@ -11,22 +11,24 @@ Kaizen-CLI の設計を支える原則集。システムアーキテクチャの
 **kaizen-cli リポジトリは配布専用（read-only）。ユーザーの知識は別の場所に蓄積する。**
 
 ```
-kaizen-cli/                ← 配布。git pull で安全に更新可能
+$KAIZEN_CLI_DIR (= kaizen-cli/)  ← 配布。git pull で安全に更新可能
   framework/
-    .claude/commands/      ← ~/.claude/commands/ にsymlink
-    .claude/skills/        ← 各プロジェクトにsymlink
-    knowledge/meta/        ← テンプレートのみ（蓄積先ではない）
+    .claude/commands/              ← ~/.claude/commands/ にsymlink
+    .claude/skills/                ← 各プロジェクトにsymlink
+    knowledge/meta/                ← テンプレートのみ（蓄積先ではない）
 
-$KAIZEN_KNOWLEDGE_DIR/     ← ユーザーの知識が蓄積される場所
-  meta/                    ← 運用ガイドライン
-  projects/                ← プロジェクトレジストリ
-  (ドメイン別ファイル)      ← reflect-learning の蓄積先
+$KAIZEN_KNOWLEDGE_DIR/             ← ユーザーの知識が蓄積される場所
+  meta/                            ← 運用ガイドライン
+  projects/                        ← プロジェクトレジストリ
+  (ドメイン別ファイル)               ← reflect-learning の蓄積先
 ```
 
 この分離により:
 - `git pull` でフレームワーク更新してもユーザーの知識と衝突しない
 - kaizen-cli のテンプレートと、ユーザーが蓄積した知識が明確に区別される
-- 環境変数（`$KAIZEN_CLI_DIR`、`$KAIZEN_KNOWLEDGE_DIR`）で両者を接続
+- 環境変数で両者を接続:
+  - `$KAIZEN_CLI_DIR`: kaizen-cli リポジトリのルート（setup.sh が自動検出）。セットアップとプロジェクト初期化時にテンプレートやスキルの参照に使用
+  - `$KAIZEN_KNOWLEDGE_DIR`: ユーザーの共有ナレッジディレクトリ。各プロジェクトからsymlink経由で常時参照
 
 ### シンボリックリンクによる横断共有
 

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -11,22 +11,24 @@ A collection of principles underpinning the design of Kaizen-CLI. This document 
 **The kaizen-cli repository is distribution-only (read-only). User knowledge is accumulated elsewhere.**
 
 ```
-kaizen-cli/                <- Distribution. Safely updatable via git pull
+$KAIZEN_CLI_DIR (= kaizen-cli/)  <- Distribution. Safely updatable via git pull
   framework/
-    .claude/commands/      <- Symlinked to ~/.claude/commands/
-    .claude/skills/        <- Symlinked into each project
-    knowledge/meta/        <- Templates only (not a knowledge store)
+    .claude/commands/              <- Symlinked to ~/.claude/commands/
+    .claude/skills/                <- Symlinked into each project
+    knowledge/meta/                <- Templates only (not a knowledge store)
 
-$KAIZEN_KNOWLEDGE_DIR/     <- Where user knowledge is accumulated
-  meta/                    <- Operational guidelines
-  projects/                <- Project registry
-  (domain-specific files)  <- Destination for reflect-learning output
+$KAIZEN_KNOWLEDGE_DIR/             <- Where user knowledge is accumulated
+  meta/                            <- Operational guidelines
+  projects/                        <- Project registry
+  (domain-specific files)          <- Destination for reflect-learning output
 ```
 
 This separation ensures:
 - Running `git pull` to update the framework never conflicts with user knowledge
 - Clear distinction between kaizen-cli templates and user-accumulated knowledge
-- Environment variables (`$KAIZEN_CLI_DIR`, `$KAIZEN_KNOWLEDGE_DIR`) connect the two
+- Environment variables connect the two:
+  - `$KAIZEN_CLI_DIR`: Root of the kaizen-cli repository (auto-detected by setup.sh). Used during setup and project initialization to locate templates and skills
+  - `$KAIZEN_KNOWLEDGE_DIR`: User's shared knowledge directory. Referenced at runtime via symlinks from each project
 
 ### Cross-Project Sharing via Symlinks
 


### PR DESCRIPTION
The environment variable was mentioned without being shown in the
architecture diagram or explained. Add it to the diagram and describe
the role of each variable ($KAIZEN_CLI_DIR for setup/init,
$KAIZEN_KNOWLEDGE_DIR for runtime via symlinks).

https://claude.ai/code/session_01KB3SoA58sRePo9mx3mUtP1