### PR TITLE
fix: add .gitattributes to enforce LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
On Windows with core.autocrlf=true, setup.sh gets CRLF line endings
which causes "/bin/bash^M: bad interpreter" errors on WSL.
Force LF for *.sh files via .gitattributes.

Closes #18

https://claude.ai/code/session_01E2cdQLJcx6a4Kf6SwzCCCK