### PR TITLE
Document two-layer knowledge architecture in Kaizen-CLI

### DIFF
--- a/docs/CONCEPT.md
+++ b/docs/CONCEPT.md
@@ -107,6 +107,29 @@ This keeps project context accurate for future sessions and for `/kaizen-suggest
 
 ---
 
+## Two Layers of Knowledge
+
+Knowledge accumulated through work naturally falls into two categories — and mixing them creates problems.
+
+**Project-specific knowledge** belongs to one project. Architecture decisions, tech stack choices, naming conventions, and stakeholder requirements are relevant in that project but irrelevant — or even misleading — in others.
+
+**Cross-project knowledge** transcends any single project. API pitfalls, domain expertise, tool quirks, coding patterns, and implicit rules are valuable everywhere. These are the insights that, once learned, should never need to be learned again.
+
+| Layer | Location | Examples |
+|-------|----------|----------|
+| **Project-specific** | `CLAUDE.md`, `docs/` | Architecture, config, roadmap, team conventions |
+| **Cross-project** | `knowledge/` (shared) | Domain expertise, pitfall records, reusable patterns, implicit rules |
+
+Kaizen-CLI keeps these two layers explicitly separate.
+
+Project-specific context stays in each project's `CLAUDE.md` and `docs/` directory. Cross-project knowledge lives in a shared `knowledge/` directory, symlinked into every project. When reflect-learning captures a reusable insight in any project, it is immediately available in every other project — without manual copying, syncing, or maintenance. Meanwhile, project-specific details do not leak across boundaries and pollute other projects' context.
+
+The decision rule is simple: **if the insight still makes sense after removing the project name, it belongs in `knowledge/`.**
+
+This separation is what turns Kaizen-CLI from a per-project tool into a cross-project knowledge platform. Without it, you would either keep all knowledge local (losing the compound effect) or dump everything into a shared space (creating noise that degrades usefulness).
+
+---
+
 ## Why It Gets Faster the More You Use It
 
 ### The Knowledge Accumulation Mechanism
@@ -132,7 +155,7 @@ Project A                          Project B
 
 Key points:
 
-1. **Project-specific information** (CLAUDE.md, docs/) and **cross-cutting knowledge** (knowledge/) are separated
+1. **Project-specific information** (CLAUDE.md, docs/) and **cross-cutting knowledge** (knowledge/) are separated — as described in the Two Layers model above
 2. knowledge/ is a symlink so all projects reference the same underlying data
 3. Every time reflect-learning accumulates knowledge, it becomes instantly available in every project
 


### PR DESCRIPTION
## Summary
Added comprehensive documentation explaining Kaizen-CLI's two-layer knowledge separation model, which distinguishes between project-specific and cross-project knowledge to prevent context pollution while enabling knowledge compound effects.

## Key Changes
- **New section: "Two Layers of Knowledge"** — Introduces the conceptual framework for separating project-specific knowledge (CLAUDE.md, docs/) from cross-project knowledge (shared knowledge/ directory)
- **Decision rule** — Provides a clear heuristic: "if the insight still makes sense after removing the project name, it belongs in knowledge/"
- **Comparison table** — Shows the location and examples of each knowledge layer
- **Explanation of benefits** — Clarifies how this separation transforms Kaizen-CLI from a per-project tool into a cross-project knowledge platform
- **Updated existing section** — Cross-referenced the new Two Layers model in the "Why It Gets Faster" section to reinforce the architectural principle

## Notable Details
The documentation emphasizes that this separation is fundamental to preventing two failure modes:
1. Keeping all knowledge local (losing compound effect across projects)
2. Dumping everything into shared space (creating noise that degrades usefulness)

The symlink mechanism ensures that cross-project knowledge captured in any project is immediately available everywhere without manual syncing.

https://claude.ai/code/session_018jQVLXz8NXXuTMLWDTcN5Y