### PR TITLE
fix: make kaizen-init-project idempotent

### DIFF
--- a/framework/.claude/skills/kaizen-init-project/SKILL.md
+++ b/framework/.claude/skills/kaizen-init-project/SKILL.md
@@ -114,6 +114,10 @@ for skill_dir in "$KAIZEN_CLI_DIR/framework/.claude/skills"/*/; do
   if [ "$skill_name" = "kaizen-init-project" ]; then
     continue
   fi
+  # べき等: 既にsymlinkが存在する場合はスキップ
+  if [ -L ".claude/skills/$skill_name" ]; then
+    continue
+  fi
   ln -s "$skill_dir" ".claude/skills/$skill_name"
 done
 ```
@@ -162,8 +166,10 @@ mkdir -p docs
 
 1. `knowledge/projects/` ディレクトリが存在しない場合は作成
 2. `knowledge/projects/INDEX.md` が存在しない場合は `$KAIZEN_CLI_DIR/framework/templates/$LANG/knowledge/projects/INDEX.md.template` から生成
-3. INDEX.mdの一覧テーブルに行を追加:
-   - `| {id} | {name} | planning | | {date} |`
+3. べき等: INDEX.md 内にプロジェクトIDが既に存在するか確認する（テーブル行の先頭カラムを検索）
+   - 既に存在する場合 → 登録をスキップし、ユーザーに「プロジェクト '{id}' は既にレジストリに登録されています」と通知
+   - 存在しない場合 → INDEX.mdの一覧テーブルに行を追加:
+     - `| {id} | {name} | planning | | {date} |`
 
 ### 10. 完了確認
 


### PR DESCRIPTION
Add idempotency checks for repeated execution:
- Step 5: Skip symlink creation if skill symlink already exists
- Step 9: Skip registry entry if project ID already exists in INDEX.md

Closes #34

https://claude.ai/code/session_019hL7q51pxPEbh8o22n1eQF