### PR TITLE
docs: add dedicated Upgrading section for existing users

### DIFF
--- a/docs/QUICKSTART.ja.md
+++ b/docs/QUICKSTART.ja.md
@@ -35,7 +35,35 @@ setup.sh が以下を行います:
 source ~/.bashrc
 ```
 
-> **Tip**: `git pull` で kaizen-cli を更新した後は、`bash kaizen-cli/setup.sh --force` を再実行すると環境変数とシンボリックリンクが最新化されます。knowledge ファイルは保持されます。
+---
+
+## アップグレード（既存ユーザー向け）
+
+kaizen-cli を新しいバージョンに更新した後は、`setup.sh --force` を実行して最新の変更を適用します。
+
+```bash
+cd kaizen-cli
+git pull
+bash setup.sh --force
+source ~/.bashrc   # または: source ~/.zshrc
+```
+
+### `--force` が行うこと
+
+| 操作 | 詳細 |
+|---|---|
+| 環境変数の更新 | シェルRCファイル内の `$KAIZEN_CLI_DIR` と `$KAIZEN_KNOWLEDGE_DIR` を再設定 |
+| シンボリックリンクの再リンク | `kaizen-init-project` スキルのシンボリックリンクを最新版に再作成 |
+| レガシーコマンドのクリーンアップ | プロジェクトローカルに移行済みの旧グローバルkaizenコマンドを削除 |
+| ナレッジ構造の自動マイグレーション | 旧フラットレイアウトのknowledgeを検出し、レジストリベースのレイアウトに移行 |
+
+### 保持されるもの
+
+- **knowledgeファイルは上書きされません** — 蓄積されたユーザーデータはすべてそのまま残ります
+- レジストリの選択と言語設定（`.lang`）は維持されます
+- 既存のプロジェクト設定は影響を受けません
+
+> **いつ `--force` を実行すべき？** `git pull` で kaizen-cli を更新するたびに実行してください。繰り返し実行しても安全です。
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -35,7 +35,35 @@ setup.sh does the following:
 source ~/.bashrc
 ```
 
-> **Tip**: After updating kaizen-cli with `git pull`, re-run `bash kaizen-cli/setup.sh --force` to update environment variables and symlinks. Knowledge files are preserved.
+---
+
+## Upgrading (Existing Users)
+
+After updating kaizen-cli to a newer version, run `setup.sh --force` to apply the latest changes.
+
+```bash
+cd kaizen-cli
+git pull
+bash setup.sh --force
+source ~/.bashrc   # or: source ~/.zshrc
+```
+
+### What `--force` does
+
+| Action | Detail |
+|---|---|
+| Update environment variables | Re-writes `$KAIZEN_CLI_DIR` and `$KAIZEN_KNOWLEDGE_DIR` in your shell RC file |
+| Re-link symlinks | Re-creates the `kaizen-init-project` skill symlink to point to the latest version |
+| Clean up legacy commands | Removes old global kaizen commands that have been replaced by project-local commands |
+| Auto-migrate knowledge structure | Detects legacy flat-layout knowledge and migrates it to the registry-based layout |
+
+### What is preserved
+
+- **Knowledge files are never overwritten** — all accumulated user data remains intact
+- Registry selection and language preference (`.lang`) are retained
+- Existing project configurations are not affected
+
+> **When should you run `--force`?** Every time you update kaizen-cli with `git pull`. It is safe to run repeatedly.
 
 ---
 


### PR DESCRIPTION
Replace the single-line Tip about `setup.sh --force` with a full
Upgrading section in both QUICKSTART.md and QUICKSTART.ja.md.
The new section explains when to run --force, what it does (env vars,
symlinks, legacy cleanup, auto-migration), and what it preserves
(knowledge files, registry, language settings).

https://claude.ai/code/session_011rg8Uaq9L2dRdQFQWsPC3y